### PR TITLE
Håndter 404 fra amplitude

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsplassen/puls/amplitude/AmplitudeClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/puls/amplitude/AmplitudeClient.kt
@@ -7,11 +7,12 @@ import io.micronaut.http.annotation.Header
 import io.micronaut.http.annotation.Headers
 import io.micronaut.http.annotation.QueryValue
 import io.micronaut.http.client.annotation.Client
+import java.net.http.HttpResponse
 
 @Client("\${amplitude.proxy_base_url}")
 @Headers(Header(name = USER_AGENT, value = "Micronaut HTTP Client"))
 interface AmplitudeClient {
     @Get("/export")
     @Header(name = ACCEPT, value = "application/zip")
-    suspend fun fetchExports(@QueryValue("start") start: String, @QueryValue("end") end: String): ByteArray
+    suspend fun fetchExports(@QueryValue("start") start: String, @QueryValue("end") end: String): HttpResponse<ByteArray>
 }

--- a/src/test/kotlin/no/nav/arbeidsplassen/puls/amplitude/AmplitudeClientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/puls/amplitude/AmplitudeClientTest.kt
@@ -12,7 +12,7 @@ class AmplitudeClientTest(private val client: AmplitudeClient) {
     fun fetchExport() {
         runBlocking {
             val tmpFile = File("/tmp/amplitude.zip")
-            tmpFile.outputStream().use { it.write(client.fetchExports("20220228T00","20220228T23")) }
+            tmpFile.outputStream().use { it.write(client.fetchExports("20220228T00","20220228T23").body()) }
         }
     }
 }


### PR DESCRIPTION
Håndter 404 fra Amplitude. P.t. blir det håndtert ved at vi logger en NPE - noe som er vrient å forstå