### PR TITLE
Fjern NPE

### DIFF
--- a/src/main/kotlin/no/nav/arbeidsplassen/puls/amplitude/AmplitudeClient.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/puls/amplitude/AmplitudeClient.kt
@@ -14,5 +14,5 @@ import java.net.http.HttpResponse
 interface AmplitudeClient {
     @Get("/export")
     @Header(name = ACCEPT, value = "application/zip")
-    suspend fun fetchExports(@QueryValue("start") start: String, @QueryValue("end") end: String): ByteArray
+    suspend fun fetchExports(@QueryValue("start") start: String, @QueryValue("end") end: String): ByteArray?
 }

--- a/src/main/kotlin/no/nav/arbeidsplassen/puls/batch/BatchFetchAmplitudeExport.kt
+++ b/src/main/kotlin/no/nav/arbeidsplassen/puls/batch/BatchFetchAmplitudeExport.kt
@@ -85,7 +85,7 @@ class BatchFetchAmplitudeExport(
         LOG.info("writing to ${exportInfo.tmpFile.name}")
         runBlocking {
             try {
-                val exportsResponse = client.fetchExports(startTime, endTime)
+                val exportsResponse = client.fetchExports(startTime, endTime) ?: ByteArray(0)
                 exportInfo.tmpFile.outputStream().use { it.write(exportsResponse) }
             } catch (e: HttpClientResponseException) {
                 LOG.warn("Failed to get export data from amplitude from $startTime to $endTime: ${e.message}. " +

--- a/src/test/kotlin/no/nav/arbeidsplassen/puls/amplitude/AmplitudeClientTest.kt
+++ b/src/test/kotlin/no/nav/arbeidsplassen/puls/amplitude/AmplitudeClientTest.kt
@@ -12,7 +12,7 @@ class AmplitudeClientTest(private val client: AmplitudeClient) {
     fun fetchExport() {
         runBlocking {
             val tmpFile = File("/tmp/amplitude.zip")
-            tmpFile.outputStream().use { it.write(client.fetchExports("20220228T00","20220228T23")) }
+            tmpFile.outputStream().use { it.write(client.fetchExports("20220228T00","20220228T23") ?: ByteArray(0)) }
         }
     }
 }


### PR DESCRIPTION
Det ser ut til at Micronaut returnerer null selv om vår interfacve definisjon av AmplitudeClient sier at det ikke skal gjøres.
Micronaut er skrevet for java og tar lite hensyn til at det kjører i kotlin omgivelser